### PR TITLE
Make repository names compatible with Bazel 0.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ java -jar target/bazel-deps-1.0-SNAPSHOT.jar <maven artifact>...
 
 --------- Add these lines to your WORKSPACE file ---------
 
-maven_jar(name = "org.hamcrest_hamcrest-core", artifact = "org.hamcrest:hamcrest-core:jar:1.3")
-maven_jar(name = "com.fasterxml.jackson.core_jackson-annotations", artifact = "com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0")
-maven_jar(name = "com.fasterxml.jackson.core_jackson-core", artifact = "com.fasterxml.jackson.core:jackson-core:jar:2.5.0")
-maven_jar(name = "com.fasterxml.jackson.core_jackson-databind", artifact = "com.fasterxml.jackson.core:jackson-databind:jar:2.5.0")
+maven_jar(name = "org_hamcrest_hamcrest_core", artifact = "org.hamcrest:hamcrest-core:jar:1.3")
+maven_jar(name = "com_fasterxml_jackson_core_jackson_annotations", artifact = "com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0")
+maven_jar(name = "com_fasterxml_jackson_core_jackson_core", artifact = "com.fasterxml.jackson.core:jackson-core:jar:2.5.0")
+maven_jar(name = "com_fasterxml_jackson_core_jackson_databind", artifact = "com.fasterxml.jackson.core:jackson-databind:jar:2.5.0")
 maven_jar(name = "junit_junit", artifact = "junit:junit:jar:4.12")
 
 
@@ -30,9 +30,9 @@ java_library(
   name="jackson-databind",
   visibility = ["//visibility:public"],
   exports = [
-    "@com.fasterxml.jackson.core_jackson-annotations//jar",
-    "@com.fasterxml.jackson.core_jackson-core//jar",
-    "@com.fasterxml.jackson.core_jackson-databind//jar",
+    "@com_fasterxml_jackson_core_jackson_annotations//jar",
+    "@com_fasterxml_jackson_core_jackson_core//jar",
+    "@com_fasterxml_jackson_core_jackson_databind//jar",
   ],
 )
 
@@ -41,7 +41,7 @@ java_library(
   visibility = ["//visibility:public"],
   exports = [
     "@junit_junit//jar",
-    "@org.hamcrest_hamcrest-core//jar",
+    "@org_hamcrest_hamcrest_core//jar",
   ],
 )
 ```
@@ -55,13 +55,13 @@ You can also exclude a set of transitive dependencies:
 
 --------- Add these lines to your WORKSPACE file ---------
 
-maven_jar(name = "commons-codec_commons-codec", artifact = "commons-codec:commons-codec:jar:1.6")
-maven_jar(name = "io.dropwizard_dropwizard-client", artifact = "io.dropwizard:dropwizard-client:jar:0.8.1")
-maven_jar(name = "io.dropwizard_dropwizard-core", artifact = "io.dropwizard:dropwizard-core:jar:0.8.1")
-maven_jar(name = "org.apache.httpcomponents_httpclient", artifact = "org.apache.httpcomponents:httpclient:jar:4.3.5")
-maven_jar(name = "org.apache.httpcomponents_httpcore", artifact = "org.apache.httpcomponents:httpcore:jar:4.3.2")
-maven_jar(name = "org.glassfish.jersey.connectors_jersey-apache-connector", artifact = "org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.17")
-maven_jar(name = "io.dropwizard.metrics_metrics-httpclient", artifact = "io.dropwizard.metrics:metrics-httpclient:jar:3.1.1")
+maven_jar(name = "commons_codec_commons_codec", artifact = "commons-codec:commons-codec:jar:1.6")
+maven_jar(name = "io_dropwizard_dropwizard_client", artifact = "io.dropwizard:dropwizard-client:jar:0.8.1")
+maven_jar(name = "io_dropwizard_dropwizard_core", artifact = "io.dropwizard:dropwizard-core:jar:0.8.1")
+maven_jar(name = "org_apache_httpcomponents_httpclient", artifact = "org.apache.httpcomponents:httpclient:jar:4.3.5")
+maven_jar(name = "org_apache_httpcomponents_httpcore", artifact = "org.apache.httpcomponents:httpcore:jar:4.3.2")
+maven_jar(name = "org_glassfish_jersey_connectors_jersey_apache_connector", artifact = "org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.17")
+maven_jar(name = "io_dropwizard_metrics_metrics_httpclient", artifact = "io.dropwizard.metrics:metrics-httpclient:jar:3.1.1")
 
 
 --------- Add these lines to your BUILD file ---------
@@ -70,13 +70,13 @@ java_library(
   name="dropwizard-client",
   visibility = ["//visibility:public"],
   exports = [
-    "@commons-codec_commons-codec//jar",
-    "@io.dropwizard.metrics_metrics-httpclient//jar",
-    "@io.dropwizard_dropwizard-client//jar",
-    "@io.dropwizard_dropwizard-core//jar",
-    "@org.apache.httpcomponents_httpclient//jar",
-    "@org.apache.httpcomponents_httpcore//jar",
-    "@org.glassfish.jersey.connectors_jersey-apache-connector//jar",
+    "@commons_codec_commons_codec//jar",
+    "@io_dropwizard_dropwizard_client//jar",
+    "@io_dropwizard_dropwizard_core//jar",
+    "@io_dropwizard_metrics_metrics_httpclient//jar",
+    "@org_apache_httpcomponents_httpclient//jar",
+    "@org_apache_httpcomponents_httpcore//jar",
+    "@org_glassfish_jersey_connectors_jersey_apache_connector//jar",
   ],
 )
 ```

--- a/src/main/java/braintree/BazelDeps.java
+++ b/src/main/java/braintree/BazelDeps.java
@@ -104,6 +104,10 @@ public class BazelDeps {
   }
 
   private static String artifactName(Artifact artifact) {
-    return artifact.getGroupId() + "_" + artifact.getArtifactId();
+    return sanitizeName(artifact.getGroupId()) + "_" + sanitizeName(artifact.getArtifactId());
+  }
+
+  private static String sanitizeName(String name) {
+    return name.replaceAll("[-.]", "_");
   }
 }


### PR DESCRIPTION
Bazel 0.2.0 forbids `.` and `-` from repository names, so replace them with `_`.  This matches the behavior of [fix_workspace.py](https://gist.github.com/kchodorow/450c6e0ab3eeab57e9d8).
