### PR TITLE
Add version to sanitized library name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>braintree</groupId>
   <artifactId>bazel-deps</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/braintree/BazelDeps.java
+++ b/src/main/java/braintree/BazelDeps.java
@@ -104,7 +104,7 @@ public class BazelDeps {
   }
 
   private static String artifactName(Artifact artifact) {
-    return sanitizeName(artifact.getGroupId()) + "_" + sanitizeName(artifact.getArtifactId());
+    return sanitizeName(artifact.getGroupId()) + "_" + sanitizeName(artifact.getArtifactId()) + "_" + sanitizeName(artifact.getVersion());
   }
 
   private static String sanitizeName(String name) {


### PR DESCRIPTION
This will make it simpler to manage a `WORKSPACE` file that includes multiple versions of the same library.

Also, I bumped the version number since this change might be considered backwards incompatible.
